### PR TITLE
Include cmvn_opts to nnet3 model distribution

### DIFF
--- a/s5_r2/build_model_dist_nnet3chain.sh
+++ b/s5_r2/build_model_dist_nnet3chain.sh
@@ -17,6 +17,7 @@ echo "and ivector extractor $ivector_extractor"
 echo "copying model and fst to $model_name"
 
 cp $model_path/final.mdl $model_name/
+cp $model_path/cmvn_opts $model_name/
 cp -r $graph_dir/* $model_name/
 cp -r conf $model_name/
 


### PR DESCRIPTION
It is needed for steps/nnet3/decode.sh to run.