### PR TITLE
Improve robustness and handling of mailabs_data

### DIFF
--- a/s5_r2/local/build_lm.sh
+++ b/s5_r2/local/build_lm.sh
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e # fail on error
 
 srcdir=data/local/lang
 dir=data/local/lm
@@ -77,7 +78,7 @@ gunzip -c $dir/train_nounk.gz | awk -v wmap=$dir/word_map 'BEGIN{while((getline<
 
 echo training kaldi_lm with 3gram-mincount
 
-rm -r data/local/lm/3gram-mincount/
+rm -r data/local/lm/3gram-mincount/ || true
 train_lm.sh --arpa --lmtype 3gram-mincount $dir
 #prune_lm.sh --arpa 6.0 $dir/3gram-mincount/
 #prune_lm.sh --arpa 8.0 $dir/3gram-mincount/

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -372,7 +372,7 @@ if [ "$add_swc_data" = true ] ; then
           utils/fix_data_dir.sh data/$x
       done
       echo "Done, now combining data (tuda_train swc_train)."
-      combine_data.sh data/train data/tuda_train data/swc_train
+      ./utils/combine_data.sh data/train data/tuda_train data/swc_train
   fi
 else
   if [ $stage -le 8 ]; then
@@ -395,12 +395,12 @@ if [ "$add_mailabs_data" = true ] ; then
     x=m_ailabs_train
     utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons
     steps/make_mfcc.sh --cmd "$train_cmd" --nj $nJobs data/$x exp/make_mfcc/$x $mfccdir
-    utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons
+    utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons, fuck the fucking fuck, this never fucking worked what the hell that is why you dont c&p code
     steps/compute_cmvn_stats.sh data/$x exp/make_mfcc/$x $mfccdir
     utils/fix_data_dir.sh data/$x
     
     echo "Done, now combining data (train m_ailabs_train)."
-    combine_data.sh data/train data/train_without_mailabs data/m_ailabs_train
+    ./utils/combine_data.sh data/train data/train_without_mailabs data/m_ailabs_train
   fi
 fi
 # Here we start the AM

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -300,13 +300,15 @@ if [ $stage -le 6 ]; then
   # deleting lexicon.txt text from a previous run, utils/prepare_lang.sh will regenerate it
   if test -f "${dict_dir}/lexicon.txt"; then
     echo "${dict_dir}/lexicon.txt already exists, removing it..."
-    rm ${dict_dir}/lexicon.txt
+    rm ${dict_dir}/lexicon.txt || true
   fi
 
   unixtime=$(date +%s)
   # Move old lang dir if it exists
   mkdir -p ${lang_dir}/old_$unixtime/
+
   mv ${lang_dir}/* ${lang_dir}/old_$unixtime/ || true
+
 
   echo "Preparing the ${lang_dir} directory...."
 
@@ -344,7 +346,7 @@ if [ "$add_swc_data" = true ] ; then
    if [ $stage -le 8 ]; then
       echo "Generating features for tuda_train, swc_train, dev and test"
       # Making sure all swc files are C-sorted 
-      rm data/swc_train/spk2utt
+      rm data/swc_train/spk2utt || true
       
       cat data/swc_train/segments | sort > data/swc_train/segments_sorted
       cat data/swc_train/text | sort | gawk 'NF>=2' > data/swc_train/text_sorted

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -16,6 +16,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e # exit on error
 
 # Set bash to 'debug' mode, it prints the commands (option '-x') and exits on :
 # -e 'error', -u 'undefined variable', -o pipefail 'error in pipeline',

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -348,7 +348,7 @@ if [ "$add_swc_data" = true ] ; then
           utils/fix_data_dir.sh data/$x
       done
       echo "Done, now combining data (tuda_train swc_train)."
-      combine_data.sh data/train data/tuda_train data/swc_train
+      ./utils/combine_data.sh data/train data/tuda_train data/swc_train
   fi
 else
   if [ $stage -le 8 ]; then
@@ -371,12 +371,12 @@ if [ "$add_mailabs_data" = true ] ; then
     x=data/m_ailabs_train
     utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons
     steps/make_mfcc.sh --cmd "$train_cmd" --nj $nJobs data/$x exp/make_mfcc/$x $mfccdir
-    utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons
+    utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons, fuck the fucking fuck, this never fucking worked what the hell that is why you dont c&p code
     steps/compute_cmvn_stats.sh data/$x exp/make_mfcc/$x $mfccdir
     utils/fix_data_dir.sh data/$x
     
     echo "Done, now combining data (train m_ailabs_train)."
-    combine_data.sh data/train data/train_without_mailabs data/m_ailabs_train
+    ./utils/combine_data.sh data/train data/train_without_mailabs data/m_ailabs_train
   fi
 fi
 # Here we start the AM

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -395,7 +395,7 @@ if [ "$add_mailabs_data" = true ] ; then
     x=m_ailabs_train
     utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons
     steps/make_mfcc.sh --cmd "$train_cmd" --nj $nJobs data/$x exp/make_mfcc/$x $mfccdir
-    utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons, fuck the fucking fuck, this never fucking worked what the hell that is why you dont c&p code
+    utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons
     steps/compute_cmvn_stats.sh data/$x exp/make_mfcc/$x $mfccdir
     utils/fix_data_dir.sh data/$x
     

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -16,6 +16,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e # exit on error
 
 stage=0
 use_BAS_dictionaries=false

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -123,7 +123,7 @@ if [ $stage -le 1 ]; then
     if [ ! -d data/wav/m_ailabs/ ]
     then
       mkdir -p data/wav/m_ailabs/
-      wget --directory-prefix=data/wav/ http://speech.tools/kaldi_tuda_de/m-ailabs.bayern.de_DE.tgz
+      wget --directory-prefix=data/wav/m_ailabs/ http://speech.tools/kaldi_tuda_de/m-ailabs.bayern.de_DE.tgz
       cd data/wav/m_ailabs/
       tar xvfz m-ailabs.bayern.de_DE.tgz
       cd ../../../
@@ -365,10 +365,10 @@ fi
 
 if [ "$add_mailabs_data" = true ] ; then
   if [ $stage -le 8 ]; then
-    mv data/train data/train_without_mailabs 
+    mv data/train data/train_without_mailabs || true
     echo "Now computing MFCC features for m_ailabs_train"
     # Now make MFCC features.
-    x=data/m_ailabs_train
+    x=m_ailabs_train
     utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons
     steps/make_mfcc.sh --cmd "$train_cmd" --nj $nJobs data/$x exp/make_mfcc/$x $mfccdir
     utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons, fuck the fucking fuck, this never fucking worked what the hell that is why you dont c&p code

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -389,7 +389,7 @@ fi
 
 if [ "$add_mailabs_data" = true ] ; then
   if [ $stage -le 8 ]; then
-    mv data/train data/train_without_mailabs 
+    mv data/train data/train_without_mailabs || true
     echo "Now computing MFCC features for m_ailabs_train"
     # Now make MFCC features.
     x=m_ailabs_train

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -371,7 +371,7 @@ if [ "$add_mailabs_data" = true ] ; then
     x=m_ailabs_train
     utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons
     steps/make_mfcc.sh --cmd "$train_cmd" --nj $nJobs data/$x exp/make_mfcc/$x $mfccdir
-    utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons, fuck the fucking fuck, this never fucking worked what the hell that is why you dont c&p code
+    utils/fix_data_dir.sh data/$x # some files fail to get mfcc for many reasons
     steps/compute_cmvn_stats.sh data/$x exp/make_mfcc/$x $mfccdir
     utils/fix_data_dir.sh data/$x
     

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -279,12 +279,12 @@ if [ $stage -le 6 ]; then
   sort -u ${dict_dir}/_lexiconp.txt ${dict_dir}/oov_lexiconp.txt > ${dict_dir}/lexiconp.txt
 
   # deleting lexicon.txt text from a previous run, utils/prepare_lang.sh will regenerate it
-  rm ${dict_dir}/lexicon.txt
+  rm ${dict_dir}/lexicon.txt || true
 
   unixtime=$(date +%s)
   # Move old lang dir if it exists
   mkdir -p ${lang_dir}/old_$unixtime/
-  mv ${lang_dir}/* ${lang_dir}/old_$unixtime/
+  mv ${lang_dir}/* ${lang_dir}/old_$unixtime/ || true 
 
   echo "Preparing the ${lang_dir} directory...."
 
@@ -322,7 +322,7 @@ if [ "$add_swc_data" = true ] ; then
    if [ $stage -le 8 ]; then
       echo "Generating features for tuda_train, swc_train, dev and test"
       # Making sure all swc files are C-sorted 
-      rm data/swc_train/spk2utt
+      rm data/swc_train/spk2utt || true
       
       cat data/swc_train/segments | sort > data/swc_train/segments_sorted
       cat data/swc_train/text | sort | awk 'NF>=2' > data/swc_train/text_sorted


### PR DESCRIPTION
adding some | true statements to make deleting files that are possibly not there safer with the -e pipefail option.

Adding relative path to scipts under ./utils as many people will not have them in their PATH.

Slight change to the location and handling of mailabs data, as the extraction and location failed for me on running the script.