### PR TITLE
Fix Stage 17 missing parameter and duplicate parameter in run_cleanup_segmentation.sh

### DIFF
--- a/s5_r2/local/run_cleanup_segmentation.sh
+++ b/s5_r2/local/run_cleanup_segmentation.sh
@@ -71,7 +71,7 @@ if [ $stage -le 4 ]; then
 
   for dset in dev test; do
     steps/decode_fmllr.sh --nj $decode_nj --num-threads $decode_num_threads \
-       --cmd "$decode_cmd"  --num-threads 4 \
+       --cmd "$decode_cmd"\
        ${cleaned_dir}/graph data/${dset} ${cleaned_dir}/decode_${dset}
 #    steps/lmrescore_const_arpa.sh --cmd "$decode_cmd" ${langdir} ${langdir}_rescore \
 #       data/${dset} ${cleaned_dir}/decode_${dset} ${cleaned_dir}/decode_${dset}_rescore

--- a/s5_r2/run.sh
+++ b/s5_r2/run.sh
@@ -749,7 +749,7 @@ fi
 
 if [ $stage -le 17 ]; then
   echo "Cleanup the corpus"
-  ./local/run_cleanup_segmentation.sh --langdir ${lang_dir}
+  ./local/run_cleanup_segmentation.sh --langdir ${lang_dir} --nj $nJobs --decode_nj $nDecodeJobs
 fi
 
 if [ $stage -le 18 ]; then


### PR DESCRIPTION
Hi,

i stumbled upon this because i can only run 7 decode jobs bc of low ram and in` run_cleanup_segmentation.sh` it was killed because it didnt use my specified decodejuobs from `cmd.sh`