### PR TITLE
Updated Spacy Dependencies

### DIFF
--- a/s5_r2/local/normalize_wiki_sentences.py
+++ b/s5_r2/local/normalize_wiki_sentences.py
@@ -22,7 +22,7 @@ import spacy
 import json
 import normalisierung
 
-nlp = spacy.load('de')
+nlp = spacy.load('de_core_news_sm')
 
 disable_pipeline = False
 filter_exlude_zeichen = True

--- a/s5_r2/local/prepare_commonvoice_data.py
+++ b/s5_r2/local/prepare_commonvoice_data.py
@@ -26,7 +26,7 @@ wav_scp_template = "sox $filepath -t wav -r 16k -b 16 -e signed - |"
 
 def process(corpus_path, output_datadir):
     common_utils.make_sure_path_exists(output_datadir)
-    nlp = spacy.load('de')
+    nlp = spacy.load('de_core_news_sm')
 
     # Common voice has repetitions and the text is not normalized
     # we cache text normalizations since they can be slow

--- a/s5_r2/local/renormalize_datadir_text.py
+++ b/s5_r2/local/renormalize_datadir_text.py
@@ -34,7 +34,7 @@ def load_lowercase_stopwords(filename='local/stopwords.de.txt'):
     return stopwords
 
 def process(text_kaldi_file):
-    nlp = spacy.load('de')
+    nlp = spacy.load('de_core_news_sm')
     texts = []
     normalize_cache = {}
     i=0


### PR DESCRIPTION
In spacy the model "de" is deprecated.

Resolves issue #55 